### PR TITLE
Add an entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ COPY katalon_studio_linux_64 /katalon
 RUN ln -s /docker-java-home/jre jre
 RUN ln -s /katalon/katalon /usr/bin/katalon
 
-COPY start_xvfb.sh /start_xvfb.sh
-RUN chmod +x /start_xvfb.sh
-
-CMD ["/start_xvfb.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ Am image that contains all of the requirements to run Katalon Studio
 [Console Mode Execution](https://docs.katalon.com/display/KD/Console+Mode+Execution).
 
 The image is based on [openjdk:slim](https://hub.docker.com/_/openjdk/), installs [Xvfb](https://www.x.org/archive/X11R7.6/doc/man/man1/Xvfb.1.xhtml) (X virtual frame buffer) and [SWT JNI](https://www.eclipse.org/swt/). Additionally the OpenJDK "Assistive Technology" option is being disabled.
+
+## Usage
+
+```sh
+docker run --rm katalon -runMode=console ...
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eo pipefail
+
+service xvfb start
+
+exec katalon "$@"

--- a/start_xvfb.sh
+++ b/start_xvfb.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-service xvfb start


### PR DESCRIPTION
While getting up and running with this image I noticed that the `xvfb` service was being started if I [started a bash session](https://github.com/katalon-studio/katalon-studio-docker/blob/45bde090199f1dfdc9c1b021227e1665ec44b942/Dockerfile#L12) or if I just [ran the container](https://github.com/katalon-studio/katalon-studio-docker/blob/45bde090199f1dfdc9c1b021227e1665ec44b942/Dockerfile#L26). Since I'm trying to automate running test during a CI process there is not a bash session involved and I have to override the default `CMD` so ultimately `xvfb` is not being started. This forced me to do something like this:

```sh
docker run katalon service xvfb start && katalon -runMode=console ...
```

This change adds an entrypoint script (with an eye toward official image conventions) that will start up `xvfb` and the run whatever command is provided. Now the following works:

```sh
docker run katalon katalon -runMode=console ...
```

One alternative to consider would be updating the entrypoint script to include the execution of Katalon like so:

```sh
exec katalon "$@"
```

This would make the resulting run command a little more "grammatically correct".

```sh
docker run katalon -runMode=console ...
```